### PR TITLE
Feat update delete behaviour

### DIFF
--- a/Tarefas.md
+++ b/Tarefas.md
@@ -41,5 +41,8 @@ PR - Integrar o chatgpt à nossa aplicação
 [x] - Adicionar o pop up para descrever o projeto e gerar tarefas a partir da descrição
 [x] - Fazer melhorias de ajustes de layout
 
+PR - Melhorar a experiência de deleção
+[] - Ao invés de usar um dialog para confirmaar, usar uma estrategia opt-out, ou seja, permitir o cliente desfazer a ação de deleção.
+
 Possíveis PRs
 2) Implementar gestão de anexos

--- a/Tarefas.md
+++ b/Tarefas.md
@@ -42,7 +42,7 @@ PR - Integrar o chatgpt à nossa aplicação
 [x] - Fazer melhorias de ajustes de layout
 
 PR - Melhorar a experiência de deleção
-[] - Ao invés de usar um dialog para confirmaar, usar uma estrategia opt-out, ou seja, permitir o cliente desfazer a ação de deleção.
+[x] - Ao invés de usar um dialog para confirmaar, usar uma estrategia opt-out, ou seja, permitir o cliente desfazer a ação de deleção.
 
 Possíveis PRs
 2) Implementar gestão de anexos

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import AuthProvider from "./provider/authProvider";
 import { SnackbarProvider } from "notistack";
 import { MyGlobalContext } from "./utils/global";
 import Routes from "./routes";
+import { useStateWithRef } from "./utils/hooks";
 
 function App() {
   const [isEditingTask, setIsEditingTask] = useState<boolean>(false);
@@ -13,16 +14,28 @@ function App() {
   const [refetchtaskStatus, setRefectchTaskStatus] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
+  const [softDeletedTasks, setSoftDeletedTasks, softDeletedTasksRef] =
+  useStateWithRef([]);
+
   return (
     <div className="App">
       <AuthProvider>
         <SnackbarProvider maxSnack={3}>
-          <MyGlobalContext.Provider value={{
-            isEditingTask, setIsEditingTask,
-            selectedTaskInput, setSelectedTaskInput,
-            refetchtaskStatus,setRefectchTaskStatus,
-            isLoading, setIsLoading
-          }}>
+        <MyGlobalContext.Provider
+            value={{
+              isEditingTask,
+              setIsEditingTask,
+              selectedTaskInput,
+              setSelectedTaskInput,
+              refetchtaskStatus,
+              setRefectchTaskStatus,
+              isLoading,
+              setIsLoading,
+              softDeletedTasks,
+              setSoftDeletedTasks,
+              softDeletedTasksRef,
+            }}
+          >
             <Routes />
           </MyGlobalContext.Provider>
         </SnackbarProvider>

--- a/src/components/TaskList/index.tsx
+++ b/src/components/TaskList/index.tsx
@@ -17,10 +17,12 @@ const TaskList = (props: TaskListProps) => {
     const { tasks, categoria } = props;
 
     const [editTaskId, setEditTaskId] = useState<null | number>(null);
-    const { setIsEditingTask } = useGlobalContext();
+    const { setIsEditingTask, softDeletedTasks } = useGlobalContext();
 
     const renderTasks = () => {
-        return tasks.map((task) => {
+        return tasks.filter(task => {
+            return softDeletedTasks.includes(task.id) === false
+          }).map((task) => {
             return (
                 <Box key={task.id}>
                     {task.id === editTaskId ? (
@@ -87,7 +89,6 @@ const TaskListWrapper = (props: TaskListWrapperProps) => {
 
     useEffect(() => {
         if (loading === false && prevTaskStatus !== taskStatus) {
-            console.log(taskStatus);
             fetchtasks();
         }
     }, [taskStatus]);

--- a/src/components/TaskTags/index.tsx
+++ b/src/components/TaskTags/index.tsx
@@ -2,7 +2,7 @@ import { Box, Chip, IconButton, Tooltip, Input } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import { useState } from "react";
 
-import { api } from '../../provider/customAxios';
+import { api } from "../../provider/customAxios";
 import { TaskTagsProps } from "./TaskTags";
 import { url_add_task_tag } from "../../utils/api";
 import { useGlobalContext } from "../../utils/global";
@@ -59,7 +59,6 @@ const TaskTags = (props: TaskTagsProps) => {
 
   const checkKeyPressed = (e: any) => {
     if (e.keyCode == 13) {
-      console.log("ENTER", e.target.value);
       addTaskTag(e.target.value);
     }
     if (e.keyCode == 27) {

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -67,8 +67,6 @@ const Login = () => {
         }
       })
       .then(data => {
-        console.log('sucesso', JSON.stringify(data))
-        console.log(data)
         if (data.responseStatus === 422 && data.data?.mensagem) {
           setErrorMessage(data.data?.mensagem)
         } else if (data.responseStatus === 400) {

--- a/src/utils/global.tsx
+++ b/src/utils/global.tsx
@@ -6,9 +6,12 @@ export type GlobalContent = {
   selectedTaskInput: string | null;
   setSelectedTaskInput: (c: string | null) => void;
   refetchtaskStatus: number;
-  setRefectchTaskStatus: (c:number) => void;
+  setRefectchTaskStatus: (c: number) => void;
   isLoading: boolean;
   setIsLoading: (c: boolean) => void;
+  softDeletedTasks: number[];
+  setSoftDeletedTasks: (c: number[]) => void;
+  softDeletedTasksRef: any;
 };
 
 export const MyGlobalContext = createContext<GlobalContent>({
@@ -20,6 +23,9 @@ export const MyGlobalContext = createContext<GlobalContent>({
   setRefectchTaskStatus: () => { },
   isLoading: false,
   setIsLoading: () => {},
+  softDeletedTasks: [],
+  setSoftDeletedTasks: () => {},
+  softDeletedTasksRef: [],
 });
 
 export const useGlobalContext = () => useContext(MyGlobalContext);

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from "react";
 
 export const usePreviousValue = (value: any) => {
   const ref = useRef(value);
@@ -8,4 +8,16 @@ export const usePreviousValue = (value: any) => {
   }, [value]);
 
   return ref.current;
+};
+
+export const useStateWithRef = (initialValue: any) => {
+  const ref = useRef(initialValue);
+  const [state, setState] = useState(initialValue);
+
+  const updateState = (newState: any) => {
+    ref.current = typeof newState === "function" ? newState(state) : newState;
+    setState(ref.current);
+};
+
+  return [state, updateState, ref];
 };


### PR DESCRIPTION
O fluxo de deleção foi alterado para torná-lo menos burocrático. Ao invés de usar um dialog para confirmar a ação, a deleção é realizada na aplicação, e se o usuário não cancelar a operação, de fato a deleção é enviada para o backend.

Para implementar esse fluxo, criamos três novos valores no contexto global, softDeletedTasks, setSoftDeletedTasks, softDeletedTasksRef e criamos um novo hook useStateWithRef. O uso do novo hook usando a referência foi necessário para que as variavel de callback usassem os valores atualizados do estado e não o valor no momento da instanciação da função. [Referencia](https://stackoverflow.com/questions/70629210/react-getting-previous-version-of-state-when-calling-a-function-in-usecontext)

Nesse PR também removemos console logs desnecessários.